### PR TITLE
Recollect totals on customer address save

### DIFF
--- a/app/code/Magento/Customer/Model/Address.php
+++ b/app/code/Magento/Customer/Model/Address.php
@@ -10,6 +10,7 @@ use Magento\Customer\Api\Data\AddressInterface;
 use Magento\Customer\Api\Data\AddressInterfaceFactory;
 use Magento\Customer\Api\Data\RegionInterfaceFactory;
 use Magento\Framework\Indexer\StateInterface;
+use Magento\Checkout\Model\Session;
 
 /**
  * Customer address model
@@ -53,6 +54,11 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress
      * @var \Magento\Customer\Model\Address\CustomAttributeListInterface
      */
     private $attributeList;
+    
+    /**
+    * @var \Magento\Checkout\Model\Session
+    */
+    private $checkoutSession;
 
     /**
      * @param \Magento\Framework\Model\Context $context
@@ -96,6 +102,7 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress
         \Magento\Framework\Indexer\IndexerRegistry $indexerRegistry,
         \Magento\Framework\Model\ResourceModel\AbstractResource $resource = null,
         \Magento\Framework\Data\Collection\AbstractDb $resourceCollection = null,
+        Session $checkoutSession,
         array $data = []
     ) {
         $this->dataProcessor = $dataProcessor;
@@ -117,6 +124,7 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress
             $dataObjectHelper,
             $resource,
             $resourceCollection,
+            $checkoutSession,
             $data
         );
     }
@@ -329,6 +337,9 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress
         if ($indexer->getState()->getStatus() == StateInterface::STATUS_VALID) {
             $this->_getResource()->addCommitCallback([$this, 'reindex']);
         }
+        $quote = $this->checkoutSession->getQuote();
+        $quote->setTriggerRecollect(true);
+        $quote->getResource()->save($quote);
         return parent::afterSave();
     }
 

--- a/app/code/Magento/Customer/Model/Address.php
+++ b/app/code/Magento/Customer/Model/Address.php
@@ -79,6 +79,7 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress
      * @param \Magento\Framework\Indexer\IndexerRegistry $indexerRegistry
      * @param \Magento\Framework\Model\ResourceModel\AbstractResource|null $resource
      * @param \Magento\Framework\Data\Collection\AbstractDb|null $resourceCollection
+     * @param \Magento\Checkout\Model\Session $checkoutSession
      * @param array $data
      *
      * @SuppressWarnings(PHPMD.ExcessiveParameterList)
@@ -108,6 +109,7 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress
         $this->dataProcessor = $dataProcessor;
         $this->_customerFactory = $customerFactory;
         $this->indexerRegistry = $indexerRegistry;
+        $this->checkoutSession = $checkoutSession;
         parent::__construct(
             $context,
             $registry,
@@ -124,7 +126,6 @@ class Address extends \Magento\Customer\Model\Address\AbstractAddress
             $dataObjectHelper,
             $resource,
             $resourceCollection,
-            $checkoutSession,
             $data
         );
     }

--- a/app/code/Magento/Customer/etc/frontend/sections.xml
+++ b/app/code/Magento/Customer/etc/frontend/sections.xml
@@ -15,4 +15,8 @@
         <section name="checkout-data"/>
         <section name="cart"/>
     </action>
+    <action name="customer/address/formPost">
+        <section name="cart"/>
+        <section name="checkout-data"/>
+    </action>
 </config>

--- a/app/code/Magento/Tax/Model/Calculation.php
+++ b/app/code/Magento/Tax/Model/Calculation.php
@@ -592,15 +592,13 @@ class Calculation extends \Magento\Framework\Model\AbstractModel
                 break;
         }
 
-        if ($customerTaxClass === null || $customerTaxClass === false) {
-            if ($customerId) {
-                $customerData = $this->customerRepository->getById($customerId);
-                $customerTaxClass = $this->customerGroupRepository
-                    ->getById($customerData->getGroupId())
-                    ->getTaxClassId();
-            } else {
-                $customerTaxClass = $this->customerGroupManagement->getNotLoggedInGroup()->getTaxClassId();
-            }
+        if ($customerId) {
+            $customerData = $this->customerRepository->getById($customerId);
+            $customerTaxClass = $this->customerGroupRepository
+                ->getById($customerData->getGroupId())
+                ->getTaxClassId();
+        } else {
+            $customerTaxClass = $this->_customerSession->getCustomer()->getTaxClassId();
         }
 
         $request = new \Magento\Framework\DataObject();


### PR DESCRIPTION
Recollect totals on customer address save. This refreshes the minicart and cart totals when a new customer group is assigned on address save. The customer group can have different tax classes assigned to it and this pull request will recollect the totals to reflect these changes. 

The outer if statement has been removed from the getRateRequest() method so that if the customerId is not set then it retrieves the customer tax class from the customer session. 

An update to the Customer/../sections.xml so that on address formPost, the cart and checkout-totals are refreshed. 

And in the afterSave() method the recollect totals flag is set. 

### Fixed Issues (if relevant)
<!--- Provide a list of fixed issues in the format magento/magento2#<issue_number>, if relevant  -->
1. https://github.com/magento/magento2/issues/10567

Testing steps can be found on the above link. (It's quite lengthy sorry!)
